### PR TITLE
using the conn name for discovering config files by tunnel id

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -7,7 +7,7 @@ check_crm                             0.7
 check_drbd                            3e0b548f55
 check_graphite                        1.0
 check_iostat                          0.0.4
-check_ipsec                           2.0
+check_ipsec                           2.1
 check_linux-procstat.pl               0.4
 check_linux-stats.pl                  1.1
 check_mem.pl                          1.8

--- a/check_ipsec
+++ b/check_ipsec
@@ -46,7 +46,7 @@ done
 [[ -z "$TUNN_ID" ]] && die 2 "[ERROR] No tunnel id specified"
 
 # Check config files
-TUNN_CFG=$(grep -r "rightid = @$TUNN_ID" /etc/ipsec.d/*.conf)
+TUNN_CFG=$(grep -r "conn $TUNN_ID" /etc/ipsec.d/*.conf)
 [ -z "$TUNN_CFG" ] && die 1 "[ERROR] No configuration found for tunnel id '${TUNN_ID}'"
 
 # Check connection status


### PR DESCRIPTION
Using the name of the ipsec connection instead the "rightid" parameter makes more sense to me.
and will make this plugin more compatible with different use cases.