### PR TITLE
Fix to deal with lvs regional formatting

### DIFF
--- a/pmp-check-lvm-snapshots
+++ b/pmp-check-lvm-snapshots
@@ -31,7 +31,7 @@ check_lvm_snapshot_fullness() {
    local FILE="$1"
    local FULL="$2"
    awk -v full="$FULL" '
-      $1 != "LV" && $1 != "File" && $6 !~ /[^0-9.]/ && $6 > full {
+      $1 != "LV" && $1 != "File" && $6 !~ /[^0-9.,]/ && $6 > full {
          print $2 "/" $1 "[" $5 "]=" $6 "%"
       }' "${FILE}"
 }
@@ -81,11 +81,11 @@ main() {
    elif grep 'WARNING: Running as a non-root user' "${TEMP}" >/dev/null 2>&1; then
       NOTE="UNK You must execute lvs with root privileges"
    else
-      local VOLS=$(check_lvm_snapshot_fullness "${TEMP}" "${OPT_CRIT}")
+      local VOLS="$(check_lvm_snapshot_fullness "${TEMP}" "${OPT_CRIT}")"
       if [ "${VOLS}" ]; then
          NOTE="CRIT LVM snapshot volumes over ${OPT_CRIT}% full: ${VOLS}"
       else
-         VOLS=$(check_lvm_snapshot_fullness "${TEMP}" "${OPT_WARN}")
+         VOLS="$(check_lvm_snapshot_fullness "${TEMP}" "${OPT_WARN}")"
          if [ "${VOLS}" ]; then
             NOTE="WARN LVM snapshot volumes over ${OPT_WARN}% full: ${VOLS}"
          fi


### PR DESCRIPTION
Consider the possibility of lvs output use the comma as decimal delimiter (in some regions) - in function check_lvm_snapshot_fullness Quote the output of the function execution to avoid the shell to try to evaluate the output string