### PR TITLE
Update check_mem.pl memory array values to match output of free from procps-ng 3.3.17 and 4.04

### DIFF
--- a/check_mem.pl
+++ b/check_mem.pl
@@ -166,8 +166,8 @@ sub sys_stats {
     my $mem_used;
     if ( $DONT_INCLUDE_BUFFERS) { $mem_used = $memory[15]; }
     else { $mem_used = $memory[8];}
-    my $swap_total = $memory[18];
-    my $swap_used = $memory[19];
+    my $swap_total = $memory[14];
+    my $swap_used = $memory[15];
     my $mem_percent = ($mem_used / $mem_total) * 100;
     my $swap_percent;
     if ($swap_total == 0) {


### PR DESCRIPTION
Tested on Ubuntu 22.04.
I noticed when running the check, the swap values were incorrect on a machine with no swap. After investigating it turned out the values of the output seem to be mapped incorrectly ( for mentioned versions ).

This PR corrects that.